### PR TITLE
Add thread support to crawler

### DIFF
--- a/ss_canton_crawler/__init__.py
+++ b/ss_canton_crawler/__init__.py
@@ -1,0 +1,1 @@
+# ss_canton_crawler package

--- a/ss_canton_crawler/__main__.py
+++ b/ss_canton_crawler/__main__.py
@@ -1,0 +1,26 @@
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+from .crawler import crawl
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple Canton crawler")
+    parser.add_argument("urls", nargs="+", help="URLs to crawl")
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=1,
+        help="Number of worker threads to use",
+    )
+    args = parser.parse_args()
+
+    if args.threads > 1:
+        with ThreadPoolExecutor(max_workers=args.threads) as executor:
+            executor.map(crawl, args.urls)
+    else:
+        for url in args.urls:
+            crawl(url)
+
+
+if __name__ == "__main__":
+    main()

--- a/ss_canton_crawler/crawler.py
+++ b/ss_canton_crawler/crawler.py
@@ -1,0 +1,3 @@
+def crawl(url: str) -> None:
+    """Stub function to simulate crawling a URL."""
+    print(f"Crawling {url}")


### PR DESCRIPTION
## Summary
- add `ss_canton_crawler` package skeleton
- implement `__main__` with `--threads` option using `ThreadPoolExecutor`
- include stub `crawl` function

## Testing
- `python -m ss_canton_crawler --threads 2 https://example.com https://example.org`
- `python -m ss_canton_crawler --threads 1 https://example.com https://example.org`


------
https://chatgpt.com/codex/tasks/task_e_688fe1cfb448832c84018a33a4c48ea4