### PR TITLE
Add test mode argument and output redirection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Test outputs
+test_results/
+output/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,28 @@
+import argparse
+from pathlib import Path
+
+from engine import crawl
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SS Canton crawler")
+    parser.add_argument(
+        "--test",
+        type=int,
+        metavar="N",
+        help="Run in test mode with a limit of N links.",
+    )
+    args = parser.parse_args()
+
+    output_dir = Path("output")
+    max_links = None
+    if args.test is not None:
+        max_links = args.test
+        output_dir = Path("test_results") / output_dir
+        print(f"[TEST MODE] max_links={max_links}, output -> {output_dir}")
+
+    crawl(max_links=max_links, output_dir=output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/engine.py
+++ b/engine.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def crawl(max_links=None, output_dir=Path("output")):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "result.txt").write_text(f"max_links={max_links}\n")
+    print(f"Crawling with max_links={max_links}; saving to {output_dir}")


### PR DESCRIPTION
## Summary
- add a minimal crawler engine and __main__.py script
- implement `--test N` CLI flag to run crawler in test mode
- redirect outputs to `./test_results` and pass `max_links` to engine

## Testing
- `python __main__.py --test 4`


------
https://chatgpt.com/codex/tasks/task_e_688fe1d0f9d8832cad0eff5863f443e7