### PR TITLE
Add comprehensive unit tests for core modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,50 @@
+import json
+import pytest
+from requests.exceptions import RequestException
+
+from crawler.auth import login, LoginError
+
+
+class DummyResponse:
+    def raise_for_status(self) -> None:
+        pass
+
+
+class FailThenSuccessSession:
+    def __init__(self, failures: int):
+        self.failures = failures
+
+    def post(self, url: str, data: dict, timeout: int):
+        if self.failures > 0:
+            self.failures -= 1
+            raise RequestException("fail")
+        return DummyResponse()
+
+
+def test_login_success_after_retries(tmp_path, monkeypatch):
+    creds = tmp_path / "creds.json"
+    creds.write_text(json.dumps({"user": "u", "password": "p"}))
+    session = FailThenSuccessSession(2)
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    returned = login(session, str(creds))
+    assert returned is session
+
+
+def test_login_invalid_credentials_file(tmp_path):
+    creds = tmp_path / "bad.json"
+    creds.write_text("not json")
+    with pytest.raises(ValueError):
+        login(None, str(creds))
+
+
+def test_login_fails_after_retries(tmp_path, monkeypatch):
+    creds = tmp_path / "creds.json"
+    creds.write_text(json.dumps({"user": "u", "password": "p"}))
+
+    class AlwaysFailSession:
+        def post(self, url: str, data: dict, timeout: int):
+            raise RequestException("fail")
+
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    with pytest.raises(LoginError):
+        login(AlwaysFailSession(), str(creds))

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,0 +1,36 @@
+import hashlib
+
+from crawler.downloads import _sha256sum, download_file
+
+
+class DummyResponse:
+    def __init__(self, content: bytes):
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class DummySession:
+    def __init__(self, content: bytes):
+        self.content = content
+
+    def get(self, url: str) -> DummyResponse:
+        return DummyResponse(self.content)
+
+
+def test_sha256sum(tmp_path):
+    file = tmp_path / "data.txt"
+    file.write_text("hello", encoding="utf-8")
+    assert _sha256sum(file) == hashlib.sha256(b"hello").hexdigest()
+
+
+def test_download_file_saves_and_deduplicates(tmp_path):
+    session = DummySession(b"filecontent")
+    counter = {}
+    path1 = download_file(session, "http://example.com/file.txt", "sec", str(tmp_path), counter)
+    assert path1.exists()
+    assert counter["sec"] == 1
+    path2 = download_file(session, "http://example.com/file.txt", "sec", str(tmp_path), counter)
+    assert path2 == path1
+    assert counter["sec"] == 1

--- a/tests/test_engine_runner.py
+++ b/tests/test_engine_runner.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+
+from engine import crawl as engine_crawl
+from runner import save_section_text
+
+
+def test_engine_crawl_creates_result_file(tmp_path, capsys):
+    output_dir = tmp_path / "out"
+    engine_crawl(max_links=5, output_dir=output_dir)
+    result_file = output_dir / "result.txt"
+    assert result_file.exists()
+    assert result_file.read_text() == "max_links=5\n"
+    captured = capsys.readouterr()
+    assert f"max_links=5" in captured.out
+
+
+def test_save_section_text_writes_clean_text(tmp_path, monkeypatch):
+    html = "<html><body><h1>Hello</h1><script>bad()</script></body></html>"
+    monkeypatch.chdir(tmp_path)
+    path = save_section_text("greeting", html, test=True)
+    expected_path = tmp_path / "test_results" / "textos" / "greeting.txt"
+    assert path.resolve() == expected_path
+    assert path.read_text(encoding="utf-8") == "Hello"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,16 @@
+from crawler.parser import extract_text
+
+
+def test_extract_text_cleans_html():
+    html = (
+        "<html><body>"
+        "<nav class='menu'><a href='/'>Home</a></nav>"
+        "<h1>Title</h1>"
+        "<p>Paragraph <a href='link'>link</a></p>"
+        "<script>ignored()</script>"
+        "<style>.x{}</style>"
+        "<img src='img.png'/>"
+        "</body></html>"
+    )
+    text = extract_text(html)
+    assert text == "Title Paragraph link"

--- a/tests/test_runner_module.py
+++ b/tests/test_runner_module.py
@@ -1,0 +1,51 @@
+from queue import Queue
+import threading
+
+from crawler.runner import load_sections, crawl as runner_crawl
+
+
+class DummyResponse:
+    def __init__(self, text: str):
+        self.text = text
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class DummySession:
+    def __init__(self, text: str):
+        self.text = text
+
+    def get(self, url: str) -> DummyResponse:
+        return DummyResponse(self.text)
+
+
+def test_load_sections(tmp_path):
+    file = tmp_path / "sections.txt"
+    file.write_text("a\n\nb\n", encoding="utf-8")
+    assert load_sections(str(file)) == ["a", "b"]
+
+
+def test_crawl_enqueues_links_respecting_max(tmp_path):
+    html = "<a href='p1'></a><a href='p2'></a>"
+    session = DummySession(html)
+    visited = {"http://example.com/start"}
+    q: "Queue[tuple[str, str]]" = Queue()
+    lock = threading.Lock()
+    runner_crawl(session, "http://example.com/start", "sec", 2, visited, q, lock)
+    assert q.get_nowait() == ("http://example.com/p1", "sec")
+    assert q.empty()
+    assert visited == {"http://example.com/start", "http://example.com/p1"}
+
+
+def test_crawl_handles_request_errors(tmp_path):
+    class ErrorSession:
+        def get(self, url: str):
+            raise Exception("boom")
+
+    visited = set()
+    q: "Queue[tuple[str, str]]" = Queue()
+    lock = threading.Lock()
+    runner_crawl(ErrorSession(), "http://example.com", "sec", None, visited, q, lock)
+    assert q.empty()
+    assert visited == set()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import pytest
+
+from crawler.utils import retry
+
+
+def test_retry_eventually_succeeds(monkeypatch):
+    calls = {"count": 0}
+
+    @retry((ValueError,), tries=3, base_delay=0)
+    def flaky():
+        calls["count"] += 1
+        if calls["count"] < 2:
+            raise ValueError("fail")
+        return "ok"
+
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    assert flaky() == "ok"
+    assert calls["count"] == 2
+
+
+def test_retry_raises_after_exhausting(monkeypatch):
+    @retry((RuntimeError,), tries=2, base_delay=0)
+    def always_fail():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    with pytest.raises(RuntimeError):
+        always_fail()


### PR DESCRIPTION
## Summary
- add tests for engine output and text saving helper
- cover parser, retries, downloads, authentication and crawling helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe79da450832c99924bd7a5536499