### PR TITLE
Integrate ss_canton_crawler with core crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ pip install -r requirements.txt
 ## Uso
 
 ```bash
-python -m ss_canton_crawler.runner --user USUARIO --password CLAVE [--base-url URL] [--output CARPETA]
+python -m ss_canton_crawler.runner --user USUARIO --password CLAVE \
+    [--base-url URL] [--output CARPETA] [--sections ARCHIVO] \
+    [--max-workers N] [--max-links M]
 ```
 
 Parámetros:
@@ -25,5 +27,9 @@ Parámetros:
 - `--password`: contraseña para autenticación.
 - `--base-url`: URL base del sitio. Por defecto `https://ss-canton.example.com`.
 - `--output`: directorio donde se almacenarán los archivos. Por defecto `output`.
+- `--sections`: archivo con las secciones iniciales a recorrer. Se aceptan rutas
+  relativas y absolutas. Si se omite sólo se descarga la página principal.
+- `--max-workers`: número de hilos de trabajo para el recorrido completo. Por defecto `4`.
+- `--max-links`: límite opcional de enlaces visitados.
 
 La aplicación creará el directorio especificado y guardará tanto las páginas descargadas como la información procesada.

--- a/crawler/runner.py
+++ b/crawler/runner.py
@@ -85,6 +85,7 @@ def run(
     sections_file: str,
     max_workers: int = 4,
     max_links: int | None = None,
+    session: requests.Session | None = None,
 ) -> None:
     """Start the crawler.
 
@@ -99,9 +100,12 @@ def run(
         Number of worker threads to spawn.
     max_links:
         Optional limit of total links to visit, used mainly for tests.
+    session:
+        Optional ``requests.Session`` to use for HTTP requests. When ``None`` a
+        new session is created internally.
     """
 
-    session = requests.Session()
+    session = session or requests.Session()
     visited: Set[str] = set()
     lock = threading.Lock()
     q: "Queue[Tuple[str, str]]" = Queue()

--- a/ss_canton_crawler/auth.py
+++ b/ss_canton_crawler/auth.py
@@ -1,31 +1,49 @@
-"""Authentication utilities for SS Canton crawler."""
+"""Authentication helpers delegating to the core :mod:`crawler` package."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
 
 import requests
+
+from crawler.auth import LoginError, login as _core_login
+
+__all__ = ["login", "LoginError"]
 
 
 def login(username: str, password: str, base_url: str) -> requests.Session:
     """Authenticate against the SS Canton service.
 
+    This wrapper funnels the provided ``username`` and ``password`` through
+    :func:`crawler.auth.login` so the retry and error handling logic of the
+    core implementation is reused.  Credentials are written to a temporary JSON
+    file compatible with the core function interface.  ``base_url`` is accepted
+    for API backwards compatibility, but the underlying authentication endpoint
+    is defined by the core implementation.
+
     Parameters
     ----------
-    username: str
+    username:
         Account username.
-    password: str
+    password:
         Account password.
-    base_url: str
-        Base URL of the SS Canton service.
+    base_url:
+        Base URL of the SS Canton service. Currently unused.
 
     Returns
     -------
     requests.Session
         Authenticated session ready to perform subsequent requests.
-
-    Raises
-    ------
-    requests.HTTPError
-        If the authentication request fails.
     """
-    session = requests.Session()
-    response = session.post(f"{base_url}/login", data={"user": username, "pass": password})
-    response.raise_for_status()
-    return session
+
+    creds = {"user": username, "password": password}
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as fh:
+        json.dump(creds, fh)
+        creds_path = fh.name
+
+    try:
+        return _core_login(requests.Session(), creds_path)
+    finally:
+        Path(creds_path).unlink(missing_ok=True)

--- a/ss_canton_crawler/crawler.py
+++ b/ss_canton_crawler/crawler.py
@@ -1,3 +1,16 @@
+"""Simple URL crawler built upon the core parser utilities."""
+
+from __future__ import annotations
+
+import requests
+
+from crawler.parser import extract_text
+
+__all__ = ["crawl"]
+
+
 def crawl(url: str) -> None:
-    """Stub function to simulate crawling a URL."""
-    print(f"Crawling {url}")
+    """Fetch ``url`` and print the cleaned text extracted from its HTML."""
+    response = requests.get(url)
+    response.raise_for_status()
+    print(extract_text(response.text))

--- a/ss_canton_crawler/downloads.py
+++ b/ss_canton_crawler/downloads.py
@@ -1,27 +1,5 @@
-"""Download helpers for fetching documents."""
-from pathlib import Path
+"""Download helpers delegating to :mod:`crawler.downloads`."""
 
-import requests
+from crawler.downloads import download_file
 
-
-def download_file(url: str, session: requests.Session, destination: Path) -> Path:
-    """Download a file and store it locally.
-
-    Parameters
-    ----------
-    url: str
-        URL of the file to download.
-    session: requests.Session
-        Authenticated session used to perform the request.
-    destination: Path
-        Location where the file will be saved.
-
-    Returns
-    -------
-    Path
-        Path to the downloaded file.
-    """
-    response = session.get(url)
-    response.raise_for_status()
-    destination.write_bytes(response.content)
-    return destination
+__all__ = ["download_file"]

--- a/ss_canton_crawler/logging_config.py
+++ b/ss_canton_crawler/logging_config.py
@@ -1,21 +1,5 @@
-"""Logging configuration utilities."""
-import logging
-from typing import Optional
+"""Wrapper around the core crawler logging configuration."""
 
+from crawler.logging_config import configure_logging as setup_logging
 
-def setup_logging(level: int = logging.INFO, log_file: Optional[str] = None) -> None:
-    """Configure logging for the crawler.
-
-    Parameters
-    ----------
-    level: int, default ``logging.INFO``
-        Logging verbosity level.
-    log_file: Optional[str]
-        File path to store logs. If ``None``, logs are output to stderr.
-    """
-    handlers = []
-    if log_file:
-        handlers.append(logging.FileHandler(log_file))
-    else:
-        handlers.append(logging.StreamHandler())
-    logging.basicConfig(level=level, handlers=handlers, format="%(levelname)s:%(name)s:%(message)s")
+__all__ = ["setup_logging"]

--- a/ss_canton_crawler/parser.py
+++ b/ss_canton_crawler/parser.py
@@ -1,22 +1,38 @@
-"""HTML parsing utilities."""
+"""HTML parsing utilities relying on the core :mod:`crawler` package."""
+
+from __future__ import annotations
+
 from typing import Dict
 
 from bs4 import BeautifulSoup
+
+from crawler.parser import extract_text
+
+__all__ = ["parse_content"]
 
 
 def parse_content(html: str) -> Dict[str, str]:
     """Parse HTML content extracted from SS Canton pages.
 
+    The function builds upon :func:`crawler.parser.extract_text` to obtain a
+    cleaned representation of the document while also returning the page title
+    for convenience.
+
     Parameters
     ----------
-    html: str
+    html:
         Raw HTML content to parse.
 
     Returns
     -------
     Dict[str, str]
-        Mapping with the parsed data extracted from the document.
+        Mapping with the parsed data extracted from the document. Contains at
+        least ``title`` and ``text`` keys.
     """
+
     soup = BeautifulSoup(html, "html.parser")
-    data = {"title": soup.title.string if soup.title else ""}
+    data = {
+        "title": soup.title.string if soup.title else "",
+        "text": extract_text(html),
+    }
     return data

--- a/ss_canton_crawler/runner.py
+++ b/ss_canton_crawler/runner.py
@@ -1,26 +1,64 @@
-"""Runner module orchestrating the SS Canton crawler."""
+"""Command line entry point leveraging the core crawler utilities."""
+
+from __future__ import annotations
+
 import argparse
 from pathlib import Path
 
 from . import auth, downloads, logging_config, parser
+from crawler.runner import run as core_run
 
 
-def run(username: str, password: str, base_url: str, output_dir: Path) -> None:
+def run(
+    username: str,
+    password: str,
+    base_url: str,
+    output_dir: Path,
+    sections: str | Path | None = None,
+    max_workers: int = 4,
+    max_links: int | None = None,
+) -> None:
     """Execute the crawler workflow.
+
+    When ``sections`` is provided the full crawling engine from the ``crawler``
+    package is invoked to traverse all links listed in that file.  Otherwise a
+    single page at ``base_url`` is downloaded and parsed.
 
     Parameters
     ----------
-    username: str
+    username:
         Login username.
-    password: str
+    password:
         Login password.
-    base_url: str
+    base_url:
         Base URL of the SS Canton site.
-    output_dir: Path
+    output_dir:
         Directory where documents and parsed data will be stored.
+    sections:
+        Optional path to a file containing initial sections to crawl. Both
+        relative and absolute paths are supported.
+    max_workers:
+        Number of worker threads for the full crawler.
+    max_links:
+        Optional limit of total links visited by the full crawler.
     """
+
     logging_config.setup_logging()
     session = auth.login(username, password, base_url)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if sections:
+        sections_path = Path(sections).expanduser().resolve()
+        core_run(
+            base_url,
+            str(sections_path),
+            max_workers=max_workers,
+            max_links=max_links,
+            session=session,
+        )
+        return
+
     response_path = output_dir / "page.html"
     downloads.download_file(f"{base_url}/page", session, response_path)
     parsed = parser.parse_content(response_path.read_text(encoding="utf-8"))
@@ -29,14 +67,26 @@ def run(username: str, password: str, base_url: str, output_dir: Path) -> None:
 
 def main() -> None:
     """CLI entry point for the crawler."""
+
     argp = argparse.ArgumentParser(description="SS Canton crawler")
     argp.add_argument("--user", required=True, help="username for authentication")
     argp.add_argument("--password", required=True, help="password for authentication")
     argp.add_argument("--base-url", default="https://ss-canton.example.com", help="base URL of the site")
     argp.add_argument("--output", default="output", help="destination directory")
+    argp.add_argument("--sections", help="file with initial sections to crawl")
+    argp.add_argument("--max-workers", type=int, default=4, help="number of worker threads")
+    argp.add_argument("--max-links", type=int, help="limit the number of visited links")
     args = argp.parse_args()
 
-    run(args.user, args.password, args.base_url, Path(args.output))
+    run(
+        args.user,
+        args.password,
+        args.base_url,
+        Path(args.output),
+        sections=Path(args.sections) if args.sections else None,
+        max_workers=args.max_workers,
+        max_links=args.max_links,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_sections_paths.py
+++ b/tests/test_sections_paths.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import os
+
+from ss_canton_crawler import runner
+
+
+def _dummy_login(user, password, base_url):
+    return object()
+
+
+def test_run_accepts_relative_sections_path(tmp_path, monkeypatch):
+    sections_file = tmp_path / "sections.txt"
+    sections_file.write_text("home", encoding="utf-8")
+
+    called = {}
+
+    def fake_core_run(base_url, sections_file_arg, **kwargs):
+        called["path"] = sections_file_arg
+
+    monkeypatch.setattr(runner, "core_run", fake_core_run)
+    monkeypatch.setattr(runner.auth, "login", _dummy_login)
+
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        runner.run("u", "p", "http://example.com", tmp_path, sections="sections.txt")
+    finally:
+        os.chdir(cwd)
+
+    assert called["path"] == str(sections_file)
+
+
+def test_run_accepts_absolute_sections_path(tmp_path, monkeypatch):
+    sections_file = tmp_path / "sections.txt"
+    sections_file.write_text("home", encoding="utf-8")
+
+    called = {}
+
+    def fake_core_run(base_url, sections_file_arg, **kwargs):
+        called["path"] = sections_file_arg
+
+    monkeypatch.setattr(runner, "core_run", fake_core_run)
+    monkeypatch.setattr(runner.auth, "login", _dummy_login)
+
+    runner.run("u", "p", "http://example.com", tmp_path, sections=sections_file)
+
+    assert called["path"] == str(sections_file)


### PR DESCRIPTION
## Summary
- wire ss_canton_crawler modules to the fully featured crawler package for auth, downloads, logging and parsing
- extend runner to optionally delegate site traversal to the core crawler implementation and expose more CLI options
- allow crawler.runner.run to reuse an authenticated session
- resolve sections file argument to support relative and absolute paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ffc83ff34832c920fa38973f0b9de